### PR TITLE
group content thematically

### DIFF
--- a/vignettes/setup.Rmd
+++ b/vignettes/setup.Rmd
@@ -2,7 +2,14 @@
 title: "Setting up Google Analytics API downloads to R"
 ---
 
-## Install
+
+This guide will walk you through the steps required to properly set up googleAnalyticsR in terms of installation and authentication.
+
+It assumes you have R installed on your machine and access rights to one or more Google Analytics accounts. In this case it will only take a few lines of R code to make a first test call to the GA API following the examples below. 
+
+The rest of this guide will give you an overview of the available set up options and cover some good practices to follow under different scenarios of use.  
+
+## 1. Install 
 
 The latest stable version of `googleAnalyticsR` is available on CRAN.
 ![CRAN](http://www.r-pkg.org/badges/version/googleAnalyticsR)
@@ -13,7 +20,7 @@ install.packages("googleAnalyticsR", dependencies = TRUE)
 
 ### Development version off GitHub
 
-You may prefer to use the latest development version is on GitHub which you can install via the below.
+You may prefer to use the latest development version on GitHub which you can install via the below.
 
 Github check status: [![Travis-CI Build Status](https://travis-ci.org/MarkEdmondson1234/googleAnalyticsR.svg?branch=master)](https://travis-ci.org/MarkEdmondson1234/googleAnalyticsR)
 
@@ -23,125 +30,61 @@ remotes::install_github("MarkEdmondson1234/googleAnalyticsR")
 
 Check out the [NEWS](https://github.com/MarkEdmondson1234/googleAnalyticsR/blob/master/NEWS.md) to see whats currently available in each version.
 
-## Dependencies
+### Dependencies
 
 `googleAnalyticsR` requires the packages described in the [`Imports` field of the `DESCRIPTION` file](https://github.com/MarkEdmondson1234/googleAnalyticsR/blob/master/DESCRIPTION) to be installed first, which it will do via `install.packages("googleAnalyticsR", dependencies = TRUE)`
 
 Note that on linux systems, due to its reliance on [`httr`]( https://CRAN.R-project.org/package=httr ) and in turn [`curl`]( https://CRAN.R-project.org/package=curl), it may require installation of these dependencies via `apt-get` or similar: `libssl-dev` and `libcurl4-openssl-dev`.
 
-## Authentication
 
-Authentication is done via the [`googleAuthR`](http://code.markedmondson.me/googleAuthR/articles/google-authentication-types.html) package, see there for advanced use cases. 
+## 2. Make first API call 
 
-For most typical day to day use, the below suits most needs:
+Once you have installed the package you can make a first call to the GA API to test the connection.
 
 ```r
 ## setup
 library(googleAnalyticsR)
 
-## This should send you to your browser to authenticate your email.
-## Authenticate with an email that has access to the Google Analytics View you want to use.
+## This should send you to your browser to authenticate your email. Authenticate with an email that has access to the Google Analytics View you want to use.
 ga_auth()
 
 ## get your accounts
 account_list <- ga_account_list()
 
-## pick a profile ID with data to query
-ga_id <- account_list[1,'viewId']
+## account_list will have a column called "viewId"
+account_list$viewId
+
+## View account_list and pick the viewId you want to extract data from. 
+ga_id <- 123456
+
+## simple query to test connection
+google_analytics(ga_id,
+date_range = c("2017-01-01", "2017-03-01"),
+metrics = "sessions",
+dimensions = "date")
 
 ```
 
-Should you need to authenticate under a new user, use `ga_auth(new_user=TRUE)`
+You can find more code examples to query the API in  [v4 API](http://code.markedmondson.me/googleAnalyticsR/articles/v4.html) and [v3 API](http://code.markedmondson.me/googleAnalyticsR/articles/v3.html) sections of the site. 
 
-When you authenticate a `ga.oauth` file will be created in your working directory.  If that file is present, then you will not need to go via Google login when you next use `ga_auth()`
+## 3.  Choose authentication method
 
-You can specify the name and location of your cache file if you pass that to the `ga_auth()` function e.g.
+To access the GA API authentication is required.  
 
-```r
-ga_auth("auth/my.oauth")
-```
+The example in the previous section used the simplest among the three available ways to authenticate to the API. If you are planning to make systematic use of the API however, it's worth to know all the available options in order to choose the most suitable.
 
-...which will create your authentication file at the location you specify, relative to your working directory. 
+Note that no matter which method you use, the authentication is actually done via the [`googleAuthR`](http://code.markedmondson.me/googleAuthR/articles/google-authentication-types.html) package. In its documentation pages you can read more about advanced use cases. 
 
-It is recommended to specify your cache file when authenticating in an RMarkdown document, since that can change the working directory during knitting. 
 
-## Service accounts
+### Authentication method #1: The default googleAnalyticsR project
 
-You can alternatively authenticate by downloading a JSON file atached to a Google Cloud service account.  More details on how to do that are on the [`googleAuthR` website](http://code.markedmondson.me/googleAuthR/articles/google-authentication-types.html#authentication-with-a-json-file-via-service-accounts).  
+The fast authentication way of the previous section worked via the default Google Project for googleAnalyticsR which is shared with all googleAnalyticsR users. Even though it is a shared project other package users are not able to see and access your GA data. 
 
-A service authentication file then needs to be created that has edit access to the GA account.  It is recommended to make a dedicated service account if you don't need it for anything else. 
+You will not need any credentials and you can directly authenticate using the `ga_auth()` function and your browser. You will not have to go through the browser verification every time though. When you authenticate a `ga.oauth` file will be created in your working directory. If that file is present, then you will not need to go via Google login when you next use `ga_auth()`
 
-1. Create your own Google Cloud Project or use an existing one.
-2. Set your own client.id/secret via `googleAuthR::gar_set_client()`
-3. Service accounts for your project can be created at this link: `https://console.cloud.google.com/iam-admin/serviceaccounts/create`
-4. The service account does not need any GCP account permissions (we do that in next step when we add to GA)
-5. After you can see your service account in the list, create a JSON key for that service account and download it somewhere safe
-6. Copy the service email e.g. `ga-access@your-project.iam.gserviceaccount.com`
-7. Login to Google Analytics and add the email to your account at the level of permissions you want.  If you want to upload data or update filters etc. then it needs at least edit permissions, if it just needs to read data then Viewer access is fine. 
-8. Make sure the GCP project the service key is for has both the Analytics API and the Analytics Reporting API access enabled.  You can reach this via the Google API & Services dashboard URL: `https://console.developers.google.com/apis/dashboard`
 
-You should now be able to use the JSON auth file to authenticate with Google Analytics API via:
 
-```r
-library(googleAnalyticsR)
-googleAuthR::gar_auth_service("your_auth_file.json")
-
-# test authentication
-al <- ga_account_list()
-```
-
-## Auto-authentication
-
-If you often use the library to access the same accounts from one machine, then it is helpful to setup auto-authentication.  This is also the most reliable way for scheduled scripts. It means you do not need to use `ga_auth()`.
-
-A short video on how to do this is available here: [googleAnalyticsR - how to do auto-authentication](https://www.youtube.com/watch?v=zgwDQu-mCOc)
-
-<iframe width="560" height="315" src="http://www.youtube.com/embed/zgwDQu-mCOc?rel=0" frameborder="0" allowfullscreen></iframe>
-
-You choose to auto-authenticate by moving your authentication cache file to a global location on your computer, that all future R sessions will use, then telling `googleAnalyticsR` where that file is when it is loaded into your R session. 
-
-This is done by creating an environment variable called `GA_AUTH_FILE` that points at your valid cache file.
-
-You can set environment variables using a `.Renviron` file or via the function `Sys.setenv()` - see `?Startup` for details. The first method is described below:
-
-1. Choose your authentication cache file - either one you have generated via `ga_auth()` or your own Google Project's service account JSON ending with file extension `.json`
-2. Create a file called `.Renviron` and place it in your user's home directory (`~` on OSX/linux or `C:\\` on Windows).  If using RStudio, you can find your the correct location directory by clicking on the `Home` breadcrumb link in your File Explorer panel.
-3. Place the absolute location of the file from step 1 into the `.Renviron` file, e.g.
-`GA_AUTH_FILE = "/Users/mark/dev/auth/ga.oauth"`.
-4. Save the file and restart your R session. 
-
-If all goes well you should see something similar to this when you load `googleAnalyticsR`:
-
-```r
-library(googleAnalyticsR)
-#>Successfully authenticated via /Users/mark/dev/auth/ga.oauth
-
-## can do authenticated calls straight away
-al <- ga_account_list()
-```
-
-## Meta data
-
-To see what dimensions and metrics are available via the API, you can use this command:
-
-```r
-## get a list of what metrics and dimensions you can use
-meta <- google_analytics_meta()
-```
-
-![](meta_data_screenshot.png)
-
-If offline, this data is also available by typing `meta`, although it won't be quite as up to date.  
-
-The meta data does not include multi-channel as they are not available, for those [see the online version](https://developers.google.com/analytics/devguides/reporting/mcf/dimsmets/).
-
-When using the library, you can call metrics and dimensions with or without the `ga:` prefix (`mcf:` for multi-channel metrics/dimensions.)
-
-## Multiple API authentication
-
-If you are using more than one API for authentication (such as Search Console), then authenticate using `googleAuthR::gar_auth()` instead, to ensure you authenticate with the correct scopes. See the [multiple authentication](http://code.markedmondson.me/googleAuthR/articles/google-authentication-types.html#multiple-authentication-tokens) section on the `googleAuthR` website for details.
-
-## Your own Google Project
+### Authentication method #2: Your own Google Project
 
 With the amount of API calls possible with this library via batching and walking, its more likely the default shared Google API project will hit the 50,000 calls per day limit.
 
@@ -151,9 +94,7 @@ To mitigate that, use your own Google Developer Console Project key, so it is no
 
 <iframe width="560" height="315" src="http://www.youtube.com/embed/4B88dRbwNfc?rel=0" frameborder="0" allowfullscreen></iframe>
 
-### Example adding your own Google Developer Console keys
-
-Set these options before any call to `ga_auth()` or other data fetching calls.
+Once you obtain the credentials for your project set these options before any call to `ga_auth()` or other data fetching calls.
 
 ```r
 options(googleAuthR.client_id = "uxxxxxxx2fd4kesu6.apps.googleusercontent.com")
@@ -176,4 +117,134 @@ If you want to use with Shiny, then set the webapp clientId/secrets.
 options(googleAnalyticsR.webapp.client_id = "xxxxx9pcab1u005cv.apps.googleusercontent.com")
 options(googleAnalyticsR.webapp.client_secret = "zcofxxxxxxElemXN5sf")
 ```
+
+
+
+Note:
+With either shared or personal project using the `ga_auth()` function, you can specify the name and location of your cache file if you pass that to the `ga_auth()` function e.g. `ga_auth("auth/my.oauth")`. This will create your authentication file at the location you specify (relative to your working directory). This can be useful when authenticating within an Rmarkdown document in which case it is recommended to specify your cache file  (an Rmarkdown document can change the working directory during knitting). 
+
+
+### Authentication method #3: Google Cloud service account
+
+You can alternatively authenticate by downloading a JSON file attached to a Google Cloud service account.  More details on how to do that are on the [`googleAuthR` website](http://code.markedmondson.me/googleAuthR/articles/google-authentication-types.html#authentication-with-a-json-file-via-service-accounts).  
+
+A service authentication file then needs to be created that has edit access to the GA account.  It is recommended to make a dedicated service account if you don't need it for anything else. 
+
+1. Create your own Google Cloud Project or use an existing one.
+2. Set your own client.id/secret via `googleAuthR::gar_set_client()`
+3. Service accounts for your project can be created at this link: `https://console.cloud.google.com/iam-admin/serviceaccounts/create`
+4. The service account does not need any GCP account permissions (we do that in next step when we add to GA)
+5. After you can see your service account in the list, create a JSON key for that service account and download it somewhere safe
+6. Copy the service email e.g. `ga-access@your-project.iam.gserviceaccount.com`
+7. Login to Google Analytics and add the email to your account at the level of permissions you want.  If you want to upload data or update filters etc. then it needs at least edit permissions, if it just needs to read data then Viewer access is fine. 
+8. Make sure the GCP project the service key is for has both the Analytics API and the Analytics Reporting API access enabled.  You can reach this via the Google API & Services dashboard URL: `https://console.developers.google.com/apis/dashboard`
+
+You should now be able to use the JSON auth file to authenticate with Google Analytics API via:
+
+```r
+library(googleAnalyticsR)
+googleAuthR::gar_auth_service("your_auth_file.json")
+
+# test authentication
+al <- ga_account_list()
+```
+
+Note: A service account is a special type of account that belongs to an application rather than an individual user. If you should use this option, chances are you are already familiar with how they work. If however you wish to find out more about when and how to use service accounts, follow the link to the Google Cloud documentation page on [Understanding Service Accounts](https://cloud.google.com/iam/docs/understanding-service-accounts) 
+
+## 4 (optional): Review useful auth options 
+
+
+This section covers some other aspects of authentication under various scenarios of use. This information is useful especially if you work systematically with Google Analytics and possibly other Google products too. 
+
+
+
+### Auto-authentication
+
+If you often use the library to access the same accounts from one machine, then it is helpful to setup auto-authentication.  This is also the most reliable way for scheduled scripts. It means you do not need to use `ga_auth()`.
+
+A short video on how to do this is available here: [googleAnalyticsR - how to do auto-authentication](https://www.youtube.com/watch?v=zgwDQu-mCOc)
+
+<iframe width="560" height="315" src="http://www.youtube.com/embed/zgwDQu-mCOc?rel=0" frameborder="0" allowfullscreen></iframe>
+
+You choose to auto-authenticate by moving your authentication cache file to a global location on your computer, that all future R sessions will use, then telling `googleAnalyticsR` where that file is when it is loaded into your R session. 
+
+This is done by creating an environment variable called `GA_AUTH_FILE` that points at your valid cache file.
+
+You can set environment variables using a `.Renviron` file or via the function `Sys.setenv()` - see `?Startup` for details. The first method is described below:
+
+1. Choose your authentication cache file - either one you have generated via `ga_auth()` or your own Google Project's service account JSON ending with file extension `.json`
+2. Create a file called `.Renviron` and place it in your user's home directory (`~` on OSX/linux or `C:\\` on Windows).  If using RStudio, you can find your the correct location directory by clicking on the `Home` breadcrumb link in your File Explorer panel or with the `path.expand("~")` command. 
+3. Place the absolute location of the file from step 1 into the `.Renviron` file, e.g.
+`GA_AUTH_FILE = "/Users/mark/dev/auth/ga.oauth"`.
+4. Save the file and restart your R session. 
+
+If all goes well you should see something similar to this when you load `googleAnalyticsR`:
+
+```r
+library(googleAnalyticsR)
+#>Successfully authenticated via /Users/mark/dev/auth/ga.oauth
+
+## can do authenticated calls straight away
+al <- ga_account_list()
+```
+
+
+### Multiple API authentification
+
+If you are using more than one API for authentication (such as Search Console), then authenticate using `googleAuthR::gar_auth()` instead, to ensure you authenticate with the correct scopes. See the [multiple authentication](http://code.markedmondson.me/googleAuthR/articles/google-authentication-types.html#multiple-authentication-tokens) section on the `googleAuthR` website for details.
+
+If you have set up a personal project then you can use the `options()` function as shown in the previous section
+
+### Multiple GA accounts
+
+If you ever need to authenticate with a new user, use `ga_auth(new_user=TRUE)`
+
+If you systematically need to fetch from several different Google analytics accounts, the easiest way to handle authentication is to have the websites all available under one email.
+If that is not possible, then you can run through the authentication steps twice, and name your auth tokens different names.
+You will need to unset the GA_AUTH_FILE in your .Renviron if you have one by either commenting it out or removing the line.
+You can then authenticate separately using `googleAuthR::gar_auth()`
+
+
+
+```r
+library(googleAnalyticsR)
+googleAuthR::gar_auth("~/auth/client_one.httr-oauth")
+
+client_one <- google_analytics(ga_id_one, date_range = my_date_range,
+metrics = "sessions", dimensions = c("date", "medium"))
+
+googleAuthR::gar_auth("~/auth/client_two.httr-oauth")
+
+client_two <- google_analytics(ga_id_two, date_range = my_date_range,
+metrics = "sessions", dimensions = c("date", "medium"))
+```
+
+### Authentication with shiny and Rmarkdown
+
+More details about these special cases of authentication are available on the corresponding sections of this site
+for [Shiny](http://code.markedmondson.me/googleAnalyticsR/articles/shiny.html) and [Rmarkdown](http://code.markedmondson.me/googleAnalyticsR/articles/rmarkdown.html)
+
+## 5 (optional): Explore the GA metrics and dimensions
+
+
+To see what dimensions and metrics are available via the API as well as their precise definition, you can use this command:
+
+```r
+## get a list of what metrics and dimensions you can use
+meta <- google_analytics_meta()
+```
+
+![](meta_data_screenshot.png)
+
+If offline, this data is also available by typing `meta`, although it won't be quite as up to date.  
+
+The meta data does not include multi-channel as they are not available, for those [see the online version](https://developers.google.com/analytics/devguides/reporting/mcf/dimsmets/).
+
+When using the library, you can call metrics and dimensions with or without the `ga:` prefix (`mcf:` for multi-channel metrics/dimensions.)
+
+
+### Where to go from here ?
+
+Once the set up is complete you are ready to start using the package to access your GA data. To give you some ideas the [v4 API page](http://code.markedmondson.me/googleAnalyticsR/articles/v4.html) of this site provides several examples of key functionalities provided by the package. 
+
 


### PR DESCRIPTION
The content of the setup page has been restructured into what I hope will make the page easier to navigate.
There is hardly any new content beyond a few section opener/closer sentences. Instead the existing content has been grouped thematically. The idea is to let the users, especially novice ones,  move sequentially and allow them to focus on the parts most relevant to them. Also to give them the chance to make their first call to the api as early as possible.  Then continue with the various options and other things they might find useful as they progress. 
I know these things can be subjective, so just let me know if you have suggestions and I 'm happy to make changes.