### PR TITLE
V3 api calls without trailing slash

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,8 @@ Authors@R: c(person("Mark", "Edmondson", email = "m@sunholo.com",
            person("David", "Watkins", email = "wm.david.watkins@gmail.com", role = "ctb"),
            person("Olivia", "Brode-Roger", email = "nibr@mit.edu", role = "ctb"),
            person("Jas", "Sohi", email = "contact@jassohi.com", role = "ctb"),
-           person("Zoran", "Selinger", email = "zselinger@gmail.com", role = "ctb"))
+           person("Zoran", "Selinger", email = "zselinger@gmail.com", role = "ctb"),
+           person("Octavian", "Corlade", email = "octavian.corlade@gmail.com", role = "ctb"))
 URL: http://code.markedmondson.me/googleAnalyticsR/
 BugReports: https://github.com/MarkEdmondson1234/googleAnalyticsR/issues
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # googleAnalyticsR 0.7.0.9000
 
 * `slow_fetch=TRUE` now respects the `max_rows` argument (#282)
+* remove trailing slash sometimes breaking v3 API calls
 
 # googleAnalyticsR 0.7.0
 

--- a/R/ga_v3_get.R
+++ b/R/ga_v3_get.R
@@ -164,7 +164,8 @@ google_analytics_3 <- function(id,
                                  type),
                           "GET",
                           pars_args = ga_pars,
-                          data_parse_function = parse_google_analytics)
+                          data_parse_function = parse_google_analytics,
+                          checkTrailingSlash = FALSE)
   
   if(multi_account_batching){
     myMessage("Fetching all ids at same time (max 10 per API call)", level = 3)


### PR DESCRIPTION
According to both the MCF and GA v3 reporting APIs, the trailing slash is not needed in the URLs. During the last couple of days, the URL with trailing slash has been intermittently working, while the one without it seems to be more reliable.

References including the URLs without the trailing slash:
 - https://developers.google.com/analytics/devguides/reporting/core/v3/reference
 - https://developers.google.com/analytics/devguides/reporting/mcf/v3/reference

Fixes #286 which has not been very easy to reproduce since it often works normally.