### PR TITLE
fix ga_account_list() "starred" column duplication error by excluding starred column with select(-dplyr::contains("starred"))

### DIFF
--- a/R/parse_functions.R
+++ b/R/parse_functions.R
@@ -225,7 +225,9 @@ parse_ga_account_summary <- function(x){
            webPropertyName = name,
            ## fix bug if profiles is NULL
            profiles = purrr::map_if(profiles, is.null, ~ data.frame())) %>%
-    select(-kind, -id, -name) %>%
+    # make sure to exclude starred column if exits to avoid 
+    # Error: Column name `starred` must not be duplicated.
+    select(-kind, -id, -name, -dplyr::contains("starred")) %>%
     unnest(cols = profiles) %>% ## unnest profiles
     mutate(viewId = id,
            viewName = name) %>%

--- a/R/parse_functions.R
+++ b/R/parse_functions.R
@@ -227,7 +227,7 @@ parse_ga_account_summary <- function(x){
            profiles = purrr::map_if(profiles, is.null, ~ data.frame())) %>%
     # make sure to exclude starred column if exits to avoid 
     # Error: Column name `starred` must not be duplicated.
-    select(-kind, -id, -name, -dplyr::contains("starred")) %>%
+    select(-kind, -id, -name, -dplyr::matches("^starred$")) %>%
     unnest(cols = profiles) %>% ## unnest profiles
     mutate(viewId = id,
            viewName = name) %>%


### PR DESCRIPTION
This fix #284.

The error happens when you unnest a data frame that contains duplicated "starred" columns so you need to drop the existing "starred" column before unnest(). Since this column does not always exist, use `-dplyr::contains("starred")`