### PR TITLE
let slow_fetch queries get full results

### DIFF
--- a/R/ga_v4_get.R
+++ b/R/ga_v4_get.R
@@ -428,7 +428,6 @@ google_analytics <- function(viewId,
     out <- fetch_google_analytics_4_slow(requests, 
                                          max_rows = max, allRows = allResults, 
                                          useResourceQuotas = useResourceQuotas)
-    allResults <- FALSE
   } else {
     ## only gets up to 50000 first time as we don't know true total row count yet
     out <- fetch_google_analytics_4(requests, 


### PR DESCRIPTION
This line is preventing queries with `slow_fetch = TRUE` from downloading more than the first batch.  If there are other implications for this PR, I can close it and create an issue showing how to reproduce the error. 

Using a call like this, that should return > 10k rows, only the first batch is returned when using `slow_fetch = TRUE`.  
```
> large_load_time <- google_analytics(viewId =  "xxxxx",
+                             date_range = c(thirty_days_ago, yesterday),
+                             dimensions = c("pagePath"),
+                             metrics = c("pageLoadSample", "avgPageLoadTime",
+                                         "avgPageDownloadTime",
+                                         "avgDomContentLoadedTime",
+                                         "exitRate"),
+                             max= -1, anti_sample = TRUE, slow_fetch = TRUE)
```