### PR TITLE
Service Account JSON Auth Amendment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Authors@R: c(person("Mark", "Edmondson", email = "m@sunholo.com",
            person("Olivia", "Brode-Roger", email = "nibr@mit.edu", role = "ctb"),
            person("Jas", "Sohi", email = "contact@jassohi.com", role = "ctb"),
            person("Zoran", "Selinger", email = "zselinger@gmail.com", role = "ctb"),
-           person("Octavian", "Corlade", email = "octavian.corlade@gmail.com", role = "ctb"))
+           person("Octavian", "Corlade", email = "octavian.corlade@gmail.com", role = "ctb"),
+           person("Maegan", "Whytock", email = "maegan.whytock@gmail.com", role = "ctb"))
 URL: https://code.markedmondson.me/googleAnalyticsR/
 BugReports: https://github.com/MarkEdmondson1234/googleAnalyticsR/issues
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # googleAnalyticsR 1.0.0.9000
 
-* ...
+* Allow path in ga_auth() to be either a file path, or a JSON string, to align with downstream libraries (GoogleAuthR and gargle)
+
 
 # googleAnalyticsR 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # googleAnalyticsR 1.0.0.9000
 
-* Allow path in ga_auth() to be either a file path, or a JSON string, to align with downstream libraries (GoogleAuthR and gargle)
+* Allow json_file argument in ga_auth() to be  any one of the forms supported for the txt argument of jsonlite::fromJSON() (typically, a file path or JSON string), to align with implementation in downstream libraries (GoogleAuthR and gargle)
 
 
 # googleAnalyticsR 1.0.0

--- a/R/auth.R
+++ b/R/auth.R
@@ -101,7 +101,7 @@
 ga_auth <- function(token = NULL, email = NULL, json_file = NULL){
   
   if(!is.null(json_file)){
-    client_email <- jsonlite::read_json(json_file)$client_email
+    client_email <- jsonlite::fromJSON(json_file)$client_email
     cli::cli_alert_info(paste("Authenticating using", client_email))
     return(gar_auth_service(json_file))
   }


### PR DESCRIPTION
This PR changes the parsing of the "json_file" argument in ga_auth() to allow for it to be any one of the forms supported for the txt argument of jsonlite::fromJSON() (typically, a file path or JSON string).

This is supported by the downstream libraries [(gar_auth_service in googleAuthR](https://github.com/MarkEdmondson1234/googleAuthR/blob/master/R/auth.R) and [credentials_service_account in gargle](https://gargle.r-lib.org/reference/credentials_service_account.html)), and allows users more flexibility for where they store their credentials (not having to save them to a file on disk).

First time submitting an open source PR - let me know if there is anything I have missed!